### PR TITLE
feat: Fix companies mapping to show and select user companies

### DIFF
--- a/src/views/UsuariosEdit.vue
+++ b/src/views/UsuariosEdit.vue
@@ -109,10 +109,12 @@
             <v-container>
               <v-row dense>
                 <v-col>
-                  <p class="body-1 font-weight-bold mb-0">Paises</p>
+                  <p class="body-1 font-weight-bold mb-0">Compañias</p>
                   <VSelectWithValidation
-                    :items="countries"
-                    v-model="user.chatsPermissions.countries"
+                    :items="companies"
+                    item-text="alias"
+                    item-value="_id"
+                    v-model="user.chatsPermissions.companies"
                     clearable
                     multiple
                     chips
@@ -257,7 +259,7 @@ export default {
         });
       }
       this.user = user;
-      this.selectedCompanies = this.user.companies.map(c => c.company);
+      this.selectedCompanies = this.user.corporation.companies.map(c => c.company);
     },
     async save() {
       this.loadingButton = true;


### PR DESCRIPTION
# Pull Request Title: Map ChatPermissions Based on Companies Instead of Countries

## Description
This pull request updates the frontend to map ChatPermissions solely based on companies, removing the dependency on countries.

## Details
- Revised the ChatPermissions mapping logic to use companies as the primary criterion instead of countries.
- Eliminated the reliance on country-based mappings to simplify and streamline the codebase.
- Updated the frontend components to reflect the new mapping approach, ensuring consistency and clarity in user interactions.

TASK => https://trello.com/c/ZlZnrhaS/106-actualizar-endpoints-para-adecuarlos-a-los-nuevos-modelos-de-la-base-de-datos