### PR TITLE
feat: Update companias mapping before update user data

### DIFF
--- a/src/views/UsuariosEdit.vue
+++ b/src/views/UsuariosEdit.vue
@@ -277,13 +277,11 @@ export default {
     },
     updateUser() {
       console.log(this.user._id);
-      this.user.companies = this.selectedCompanies.map(c => {
-        return {
-          company: {
-            _id: c,
-          }
-        };
-      });
+      this.user.corporation.companies = this.selectedCompanies.map(c => ({
+        company: {
+          _id: c,
+        }
+      }));
       this.$store.dispatch("usersModule/update", {
         id: this.user._id,
         data: this.user,


### PR DESCRIPTION
## Description
Fix `update` user companies.

## Details:
- Remove user.companies property..
- Map companies selected and save them in user.corporation.companies.

Task: https://trello.com/c/ChCZMpcF/120-arreglar-la-actualizacion-de-datos-del-usuario-especificamente-en-la-seccion-de-seleccionar-companias