### PR TITLE
feat: Add company parameter to create a new telegram group

### DIFF
--- a/src/views/TelegramGroups.vue
+++ b/src/views/TelegramGroups.vue
@@ -292,6 +292,7 @@ export default {
       } else {
         //create item
         try {
+          this.editedItem.company = this.$store.getters["authModule/getCurrentCompany"].company._id;
           let newItem = await this.$store.dispatch(
             "telegramGroupsModule/create",
             this.editedItem


### PR DESCRIPTION
## Description
Fix `create` telegram groups.

## Details:
- Add company  parameter to create telegram groups.

Task: https://trello.com/c/i9ElNb2Y/125-arreglar-el-bug-de-creacion-de-grupos-de-telegram-donde-no-aparecen-en-la-lista-despues-de-crear-uno