### PR TITLE
Dev fe 0126

### DIFF
--- a/src/components/CompaniesSelector.vue
+++ b/src/components/CompaniesSelector.vue
@@ -40,24 +40,6 @@ export default {
       companies: [],
     };
   },
-  watch: {
-    initialData: {
-      handler() {
-        console.log("handelr");
-        this.selectedCompanies = this.multiple
-          ? this.initialData.map(
-            (el) =>
-              this.companies[
-              this.companies.findIndex((el2) => el2._id === el._id)
-              ]
-          )
-          : this.companies.findIndex(
-            (el) => el === (this.initialData ? this.initialData[0]._id : null)
-          );
-      },
-      immediate: true,
-    },
-  },
   async created() {
     await this.$store.dispatch("companiesModule/list"),
     this.initialize();
@@ -68,6 +50,21 @@ export default {
       this.companies = this.$deepCopy(
         this.$store.state.companiesModule.companies,
       );
+      this.handleInitialData();
+    },
+    handleInitialData () {
+      this.selectedCompanies = this.multiple
+          ? this.initialData.map(
+            (el) => {
+              console.log("this.initialData, this.companies");
+              console.log(this.initialData, this.companies);
+              return this.companies.findIndex((el2) => el2._id === el._id);
+            }
+              
+          )
+          : this.companies.findIndex(
+            (el) => el === (this.initialData ? this.initialData[0]._id : null)
+          );
     },
     getCompanies(selectedCompanies) {
       console.log("get companies", selectedCompanies);

--- a/src/views/Leads.vue
+++ b/src/views/Leads.vue
@@ -63,6 +63,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -996,6 +997,7 @@ export default {
 
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     console.log(this.sourceSelectList);
     this.rolAuth();
@@ -1028,7 +1030,7 @@ export default {
         body["todofullLabels"] = this.selectedLabels.map((el) => el._id);
       }
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       if (this.showLeadsWithoutLabel) {
         body["showLeadsWithoutLabels"] = true;
@@ -1096,6 +1098,9 @@ export default {
             });
         }
       });
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsCompraFallida.vue
+++ b/src/views/LeadsCompraFallida.vue
@@ -60,6 +60,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -522,6 +523,7 @@ export default {
 
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth();
   },
@@ -551,7 +553,7 @@ export default {
       body["estado"] = "COMPRA FALLIDA";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -575,6 +577,9 @@ export default {
         })
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsCompraRealizada.vue
+++ b/src/views/LeadsCompraRealizada.vue
@@ -60,6 +60,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -521,6 +522,7 @@ export default {
 
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth();
   },
@@ -550,7 +552,7 @@ export default {
       body["estado"] = "COMPRA REALIZADA";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -573,6 +575,9 @@ export default {
         })
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsInformados.vue
+++ b/src/views/LeadsInformados.vue
@@ -60,6 +60,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -433,6 +434,7 @@ export default {
 
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth(); 
   },
@@ -464,7 +466,7 @@ export default {
       body["estado"] = "INFORMADO AL AGENTE";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -486,6 +488,9 @@ export default {
         })
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsNuevos.vue
+++ b/src/views/LeadsNuevos.vue
@@ -29,6 +29,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -533,6 +534,7 @@ export default {
   },
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth();
   },
@@ -562,7 +564,7 @@ export default {
       body["estado"] = "SIN ASIGNAR";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -584,6 +586,9 @@ export default {
         (telefono) => telefono.active == true
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsReconectar.vue
+++ b/src/views/LeadsReconectar.vue
@@ -60,6 +60,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -525,6 +526,7 @@ export default {
 
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth();
   },
@@ -553,7 +555,7 @@ export default {
       body["estado"] = "RE-CONECTAR";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -578,6 +580,9 @@ export default {
         })
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(

--- a/src/views/LeadsWhatsapp.vue
+++ b/src/views/LeadsWhatsapp.vue
@@ -29,6 +29,7 @@
                 <v-sheet max-width="700">
                   <CompaniesSelector
                     :multiple="true"
+                    :initial-data="[getCurrentCompany()]"
                     @onSelectedCompanies="
                       selectedCompanies = $event;
                       initialize(
@@ -533,6 +534,7 @@ export default {
   },
   mounted() {
     this.$store.commit("loadingModule/showLoading");
+    this.selectedCompanies = [this.getCurrentCompany()];
     this.initialize(this.buildPayloadPagination(null, this.buildSearch()));
     this.rolAuth();
   },
@@ -562,7 +564,7 @@ export default {
       body["channel"] = "whatsapp";
       if (this.telefonoId) body["telefonoId"] = this.telefonoId._id;
       if (this.selectedCompanies.length > 0) {
-          body["companies"] = this.selectedCompanies.map(c => c._id);
+          body["companies"] = this.selectedCompanies.map(c => c?._id);
       }
       await Promise.all([
         this.$store.dispatch("cleanLeadsModule/list", body),
@@ -584,6 +586,9 @@ export default {
         (telefono) => telefono.active == true
       );
       this.dataTableLoading = false;
+    },
+    getCurrentCompany() {
+      return this.$store.getters["authModule/getCurrentCompany"].company;
     },
     buildPayloadPagination(page, searchPayload) {
       return buildPayloadPagination(


### PR DESCRIPTION
## Description
Add pre selected companies in Leads* views, according to current companie selected on user session.

## Details:
- Update CompaniesSelector component, to remove watch state, and move this to a method where its called after muonted.
- Update Leads.* views to add default companie selected.

Task: https://trello.com/c/5Q4OQfjx/126-agregar-el-preselecionado-de-countries-en-la-vista-de-leads-en-base-a-la-compania-actual-de-la-sesion-del-usuario