### PR TITLE
feat: Add telegram/routines drawer item

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -271,18 +271,32 @@
 
           <v-list-item-content> Bots </v-list-item-content>
         </v-list-item>
-
-        <v-list-item
-          active-class="primary custom2"
-          :to="{ name: 'TelegramGroups' }"
-          v-if="checkAuth('ChatBot/Bots', 'Bots')"
-        >
-          <v-list-item-icon>
-            <v-icon>mdi-check</v-icon>
-          </v-list-item-icon>
-
-          <v-list-item-content> Telegram </v-list-item-content>
-        </v-list-item>
+        <v-list-group
+            color="white"
+            :value="false"
+            no-action
+            sub-group
+            active-class="primary custom2"
+            v-if="checkAuth('ChatBot/Bots', 'Bots')"
+          >
+            <template v-slot:activator>
+              <v-list-item-content>
+                <v-list-item-title>Telegram</v-list-item-title>
+              </v-list-item-content>
+            </template>
+            <v-list-item
+              active-class="primary custom2"
+              :to="{ name: 'TelegramGroups' }"
+            >
+              <v-list-item-content> Grupos </v-list-item-content>
+            </v-list-item>
+            <v-list-item
+              active-class="primary custom2"
+              :to="{ name: 'TelegramRoutines' }"
+            >
+              <v-list-item-content> Rutinas </v-list-item-content>
+            </v-list-item>
+          </v-list-group>
         <v-list-group
           color="white"
           :value="false"


### PR DESCRIPTION
## Description
Add  `telegram/routines` drawer item.

## Details:
- Add telegram drawer group.
- Add telegram/groups item.
- Add telegram/routines item.

Task: https://trello.com/c/zHpk9T4z/130-agregar-item-de-navegacion-en-el-drawer-para-acceder-a-telegram-rutinas