### PR TITLE
feat: Remove 'Grupo' duplicated drawer list item

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -100,13 +100,6 @@
           >
             <v-list-item-content> Grupos </v-list-item-content>
           </v-list-item>
-          <v-list-item
-            active-class="primary custom2"
-            :to="{ name: 'Groups' }"
-            v-if="checkAuth('Configuracion/TodoFull', 'Groups')"
-          >
-            <v-list-item-content> Grupos </v-list-item-content>
-          </v-list-item>
         </v-list-group>
         <v-list-group
           color="white"


### PR DESCRIPTION
## Description
Remove 'Grupo' duplicated drawer list item

Task: https://trello.com/c/odDDlZjl/142-eliminar-doble-sidebar-item-grupo-del-dashboard