### PR TITLE
Dev fe 0146

### DIFF
--- a/src/components/core/Drawer.vue
+++ b/src/components/core/Drawer.vue
@@ -84,7 +84,7 @@
             :to="{ name: 'Locaciones' }"
             v-if="checkAuth('Configuracion/TodoFull', 'Locaciones')"
           >
-            <v-list-item-content> Ubicaciones </v-list-item-content>
+            <v-list-item-content> Locaciones </v-list-item-content>
           </v-list-item>
           <v-list-item
             active-class="primary custom2"

--- a/src/views/Usuarios.vue
+++ b/src/views/Usuarios.vue
@@ -259,7 +259,7 @@ export default {
         value: "email",
       },
       {
-        text: "Companies",
+        text: "Compañias",
         align: "left",
         sortable: true,
         value: "corporation",


### PR DESCRIPTION
## Description
Update 'Ubicaciones' label instead of 'Locaciones' on drawer item

## Details:
- Update 'Ubicaciones' label instead of 'Locaciones' on drawer item
- Update 'companies' label instead of 'compañias' on users view

Task: https://trello.com/c/cBtqJSWT/146-cambiar-el-texto-del-item-del-drawer-ubicaciones-a-locaciones-asi-como-el-campo-companies-de-la-lista-de-usuario-a-compa%C3%B1ias