### PR TITLE
feat: Add companies parameter to filter by companies in Woocommerce view

### DIFF
--- a/src/views/Woocommerce.vue
+++ b/src/views/Woocommerce.vue
@@ -332,7 +332,9 @@ export default {
         (locacion) => locacion.value !== undefined
       )
 
-      const res = await vendorsApi.list()
+      const res = await vendorsApi.list({
+        companies: [this.$store.getters["authModule/getCurrentCompany"].company._id],
+      })
       this.vendors = res.data.payload
       console.log('🚀 Aqui *** -> this.vendors', this.vendors)
     },


### PR DESCRIPTION
## Description
Add the `companies` parameter to filter by companies in the Woocommerce view

Task: https://trello.com/c/xgPR5NdT/151-filtrar-los-vendedores-de-la-vista-de-woocommerce-en-el-dashboard