### PR TITLE
feat: Add company property to create a new woocommerce

### DIFF
--- a/src/views/Woocommerce.vue
+++ b/src/views/Woocommerce.vue
@@ -399,6 +399,7 @@ export default {
         }
       } else {
         //create item
+        this.editedItem.company = this.$store.getters["authModule/getCurrentCompany"].company._id;
         try {
           let newItem = await this.$store.dispatch(
             'woocommercesModule/create',


### PR DESCRIPTION
## Description
Add company property to create a new woocommerce

Task: https://trello.com/c/ByoXYr9M/152-no-se-muestran-los-woocommerce-creados-en-el-dashboard