### PR TITLE
fix: Get vendors name with new wocommerce data structure

### DIFF
--- a/src/views/Woocommerce.vue
+++ b/src/views/Woocommerce.vue
@@ -157,7 +157,7 @@
             </v-container>
           </template>
           <template v-slot:item.vendor="{ item }">
-            {{ item.vendor ? getVendor(item.vendor).name : '' }}
+            {{ (item.vendor)?.name }}
           </template>
           <template v-slot:item.action="{ item }">
             <v-btn


### PR DESCRIPTION
## Description
Refactor method for retrieving vendor name

Task: https://trello.com/c/RiWXLGzz/282-actualizar-endpoint-de-listado-woocommerce-para-agregar-los-datos-de-los-vendor