### PR TITLE
fix: Get the woocommerce domain value from new data structure

### DIFF
--- a/src/views/EcommerceProducts/Variations.vue
+++ b/src/views/EcommerceProducts/Variations.vue
@@ -161,9 +161,7 @@
             <span v-if="item.url || item.woocommerceId">
               {{
                 item.url ||
-                  $store.state.woocommercesModule.woocommerces.find(
-                    (el) => el._id === item.woocommerceId
-                  ).domain
+                  item.woocommerceId.domain
               }}
             </span>
           </template>


### PR DESCRIPTION
## Description
Get the woocommerce domain value from new data structure

Task: https://trello.com/c/cJ3ZLahy/323-extraer-el-dominio-del-ecommerce-product-mediante-el-nuevo-esquema-de-los-items-recuperados-de-la-base-de-datos