### PR TITLE
fix: Update the page value after get new filtered data

### DIFF
--- a/src/views/EcommerceProducts/Variations.vue
+++ b/src/views/EcommerceProducts/Variations.vue
@@ -529,10 +529,12 @@ export default {
     async search() {
       clearTimeout(this.delayTimer);
       this.delayTimer = setTimeout(() => {
+        this.page = 1;
         this.initialize(this.page);
       }, 600);
     },
     currentSourceUrl() {
+      this.page = 1;
       this.initialize(this.page);
     },
   },

--- a/src/views/EcommerceProducts/index.vue
+++ b/src/views/EcommerceProducts/index.vue
@@ -928,6 +928,7 @@ export default {
     async search() {
       clearTimeout(this.delayTimer);
       this.delayTimer = setTimeout(() => {
+        this.page = 1;
         this.initialize(this.page);
       }, 600);
     },

--- a/src/views/MarketplaceProducts/Variations.vue
+++ b/src/views/MarketplaceProducts/Variations.vue
@@ -338,7 +338,7 @@ export default {
     },
     handleSearchUpdate(value) {
       this.search = value
-
+      this.page = 1;
       this.debounce(() => this.initialize(this.page))
     },
     async handleStockSave(item) {


### PR DESCRIPTION
## Description
Restart page value after get filtered data

Task: https://trello.com/c/e0lY80QV/324-reiniciar-el-paginado-de-la-vista-variaciones-de-woocommerce-cada-que-se-haga-un-filtro