### PR TITLE
feat: add isLive capability toggle to bot form

### DIFF
--- a/src/classes/Bots.js
+++ b/src/classes/Bots.js
@@ -20,5 +20,6 @@ export default () => ({
   capabilities: {
     isEligibleForCampaigns: true,
     isEligibleForMassiveMessaging: true,
+    isLive: false,
   },
 });

--- a/src/views/Facebook.vue
+++ b/src/views/Facebook.vue
@@ -394,6 +394,12 @@
                                 label="Elegible para Mensajería Masiva"
                               ></v-checkbox>
                             </v-col>
+                            <v-col cols="12" sm="6">
+                              <v-checkbox
+                                v-model="editedItem.capabilities.isLive"
+                                label="En Vivo"
+                              ></v-checkbox>
+                            </v-col>
                           </v-row>
 
                           <v-divider></v-divider>


### PR DESCRIPTION
## Qué
Agrega el toggle **En Vivo** (`capabilities.isLive`) al formulario de bots.

- `src/classes/Bots.js`: nuevo campo `capabilities.isLive: false`.
- `src/views/Facebook.vue`: `v-checkbox` "En Vivo" junto a las capacidades existentes, espejando el patrón actual. Se guarda por el flujo `botsModule/update` (PUT /api/bots/:id) sin cambios.

Pareja del backend: ViktorJJF/todo-mujeron#310 (modelo + endpoints + from_live).