### PR TITLE
fix: campaign bulk-schedule button — clear feedback + timeout (never appears stuck)

### DIFF
--- a/src/services/api/marketingCampaigns.js
+++ b/src/services/api/marketingCampaigns.js
@@ -8,6 +8,12 @@ export const PROGRAMMED_CHUNK_STATUSES = Object.freeze({
   SENT_WITH_SOME_ERRORS: "sent_with_some_errors",
 });
 
+// WHY: persisting a PROGRAMMED chunk is a ~50-100ms DB write, so a stall means the
+// network/proxy is broken — surface it in seconds instead of hiding behind the 60s
+// global axios timeout. NOT applied to immediate sends: those legitimately run the
+// ~45-min per-lead loop before responding.
+const SCHEDULE_SEND_CHUNK_TIMEOUT_MS = 30000;
+
 export default {
   list(params) {
     return axios.get("/api/marketing-campaigns", { params });
@@ -40,7 +46,16 @@ export default {
         ...scheduleAPIOptions,
       };
     }
-    return axios.post("/api/marketing-campaigns/send_chunk", payload);
+    // Bound the wait only for the fast programmed (scheduling) path; immediate
+    // sends keep the global timeout because their server loop can take ~45 min.
+    const requestConfig = scheduleAPIOptions?.isProgrammed
+      ? { timeout: SCHEDULE_SEND_CHUNK_TIMEOUT_MS }
+      : undefined;
+    return axios.post(
+      "/api/marketing-campaigns/send_chunk",
+      payload,
+      requestConfig
+    );
   },
   chunkDetail(chunkPage, chunkSize, segment, campaign) {
     const payload = {

--- a/src/views/MarketingCampaigns.vue
+++ b/src/views/MarketingCampaigns.vue
@@ -2936,6 +2936,18 @@ export default {
           this.bulkScheduleDialog.loading = false;
           return;
         }
+        // WHY: if chunks are missing/empty, item.chunks.map below throws
+        // synchronously and the spinner would never clear (nothing gets sent).
+        if (!Array.isArray(item.chunks) || item.chunks.length === 0) {
+          buildSuccess(
+            "No hay tandas para programar.",
+            this.$store.commit,
+            "warning"
+          );
+          this.bulkScheduleDialog.loading = false;
+          return;
+        }
+
         const base = this.bulkStartAtDateTime || now;
         let errorOccurred = false;
         if (!item.scheduledChunks) this.$set(item, "scheduledChunks", {});
@@ -3044,9 +3056,13 @@ export default {
             const actualScheduledCount = results.filter(
               (r) => r && !r.status
             ).length; // successful API calls
-            const skippedCount = results.filter(
+            const alreadySentCount = results.filter(
               (r) => r && r.status === "skipped_scheduling_already_sent"
             ).length;
+            const alreadyProcessingCount = results.filter(
+              (r) => r && r.status === "skipped_scheduling_processing"
+            ).length;
+            const skippedCount = alreadySentCount + alreadyProcessingCount;
             // errorOccurred is already tracked for API call failures
 
             let messages = [];
@@ -3059,7 +3075,11 @@ export default {
             }
             if (skippedCount > 0) {
               messages.push(
-                `${skippedCount} tanda(s) ya habían sido enviadas y no se reprogramaron.`
+                `${skippedCount} tanda(s) se omitieron porque ya estaban ${
+                  alreadyProcessingCount > 0
+                    ? "programadas o en proceso"
+                    : "enviadas"
+                }.`
               );
             }
             if (errorOccurred) {
@@ -3067,7 +3087,18 @@ export default {
                 "Algunas tandas no pudieron ser programadas debido a errores."
               );
             }
-            if (messages.length === 0 && item.chunks.length > 0) {
+            // WHY: when nothing new was scheduled because every tanda was already
+            // programmed, say so explicitly — otherwise the closing spinner reads
+            // to the user as "se quedó pegado y no envió".
+            if (
+              actualScheduledCount === 0 &&
+              skippedCount > 0 &&
+              !errorOccurred
+            ) {
+              messages = [
+                "Todas las tandas ya estaban programadas o enviadas. No se reprogramó ninguna.",
+              ];
+            } else if (messages.length === 0 && item.chunks.length > 0) {
               messages.push("No se programaron nuevas tandas.");
             } else if (item.chunks.length === 0) {
               messages.push("No hay tandas para programar.");
@@ -3083,6 +3114,16 @@ export default {
 
             // await this.refreshCampaignItem(item); // Refresh item instead of full initialize
             this.closeBulkScheduleDialog();
+          })
+          .catch((err) => {
+            // WHY: defensive — the per-chunk .catch already handles API failures,
+            // but never let a throw in post-processing leave the button spinning.
+            console.error("Error finalizando la programación de tandas:", err);
+            buildSuccess(
+              "Ocurrió un error al finalizar la programación. Recarga e intenta de nuevo.",
+              this.$store.commit,
+              "error"
+            );
           })
           .finally(() => {
             this.bulkScheduleDialog.loading = false;


### PR DESCRIPTION
## Problem
The 'Programar todas las tandas' button could appear stuck/loading with no clear feedback, reading as 'se quedó pegado y no envió'. RCA (ultracode, verified against the deployed bundle + prod logs + DB): nothing was actually sent/duplicated — the request either dispatched 0 POSTs (all tandas already scheduled → silently skipped) or stalled with no explicit feedback. Deployed build already has `.finally` + 60s axios timeout, so it was never literally infinite.

## Changes (surgical, low-risk)
- **Clear feedback**: count both skip types (already-sent AND already-processing) and show an explicit toast when nothing new was scheduled because every tanda was already programmed — instead of a silent close.
- **Guard `item.chunks`**: empty/undefined chunks would throw synchronously and never clear the spinner; now returns with a message.
- **Defensive `.catch`** on the Promise.all chain so post-processing never leaves the button spinning.
- **Short explicit timeout (30s)** on the *programmed* send_chunk only (immediate sends keep 60s since their server loop can take ~45 min).

Skips the risky 'reset stale scheduled_pending_api' change (would risk double-scheduling).

Deployed to prod as a **hotfix built from d510b86** (current prod frontend commit) + this fix only — NOT a full master build (master has 5 unbuilt commits: category hierarchy + isLive UI, intentionally excluded).

🤖 RCA + fix via ultracode workflow, /check-patterns reviewed.