### PR TITLE
feat: landing público provisional en todofull.club (para Meta App Review)

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -5,12 +5,16 @@ import { localStorageGet } from "@/utils/utils";
 Vue.use(Router);
 
 let routes = [
-  // root path
+  // root path — public provisional landing (no auth)
   {
     path: "/",
     name: "LandingPage",
-    redirect: "/login",
-    component: () => import("./views/LandingPage.vue"),
+    component: () => import("./views/Landing.vue"),
+  },
+  {
+    path: "/privacy-policy",
+    name: "PrivacyPolicy",
+    component: () => import("./views/PrivacyPolicy.vue"),
   },
   {
     path: "/login",

--- a/src/views/Landing.vue
+++ b/src/views/Landing.vue
@@ -1,0 +1,96 @@
+<template>
+  <v-container fluid class="landing pa-0">
+    <v-row no-gutters align="center" justify="center" class="landing__hero">
+      <v-col cols="12" sm="10" md="8" lg="6" class="text-center px-6 py-12">
+        <v-img
+          src="/images/logo/todofull.jpg"
+          alt="Todofull"
+          max-width="120"
+          class="landing__logo mx-auto mb-6"
+        />
+
+        <h1 class="landing__brand white--text mb-4">Todofull</h1>
+
+        <p class="landing__tagline white--text mb-8">
+          La plataforma que centraliza las integraciones de tu ecommerce y
+          descubre patrones en los datos de tus clientes.
+        </p>
+
+        <v-btn
+          color="warning"
+          x-large
+          rounded
+          :to="{ name: 'login' }"
+          class="font-weight-bold px-8"
+        >
+          Ingresar
+        </v-btn>
+
+        <div class="mt-10">
+          <router-link
+            :to="{ name: 'PrivacyPolicy' }"
+            class="landing__link white--text"
+          >
+            Política de Privacidad
+          </router-link>
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: "Landing",
+};
+</script>
+
+<style scoped>
+.landing {
+  min-height: 100vh;
+}
+
+.landing__hero {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #28156c 0%, #3a1f96 100%);
+}
+
+.landing__brand {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: -1px;
+}
+
+.landing__tagline {
+  font-size: 1.25rem;
+  line-height: 1.7rem;
+  opacity: 0.92;
+  max-width: 640px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.landing__logo {
+  border-radius: 16px;
+}
+
+.landing__link {
+  text-decoration: underline;
+  opacity: 0.85;
+  font-size: 0.95rem;
+}
+
+.landing__link:hover {
+  opacity: 1;
+}
+
+@media (max-width: 600px) {
+  .landing__brand {
+    font-size: 2.25rem;
+  }
+
+  .landing__tagline {
+    font-size: 1.05rem;
+  }
+}
+</style>

--- a/src/views/PrivacyPolicy.vue
+++ b/src/views/PrivacyPolicy.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-container class="privacy py-12">
+    <v-row justify="center">
+      <v-col cols="12" md="8" lg="7">
+        <router-link :to="{ name: 'LandingPage' }" class="text-decoration-none">
+          <v-btn text color="primary" small class="mb-6 px-0">
+            <v-icon left small>mdi-arrow-left</v-icon>
+            Volver
+          </v-btn>
+        </router-link>
+
+        <h1 class="text-h4 font-weight-bold mb-2">Política de Privacidad</h1>
+        <p class="text--secondary mb-8">Última actualización: julio de 2026</p>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">1. Quiénes somos</h2>
+          <p>
+            Todofull es una plataforma que permite a los negocios de ecommerce
+            gestionar sus integraciones y analizar los datos de sus clientes.
+            Esta política describe cómo tratamos la información que recopilamos.
+          </p>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">2. Datos que recopilamos</h2>
+          <p>
+            Recopilamos los datos que nos proporcionas al crear una cuenta y al
+            conectar tus integraciones, incluida la información de tu cuenta de
+            WhatsApp Business (nombre del negocio, número de teléfono e
+            identificadores de la cuenta) que autorizas a través de Meta, así
+            como los mensajes y contactos necesarios para operar el servicio.
+          </p>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">3. Cómo usamos tus datos</h2>
+          <p>
+            Usamos estos datos únicamente para prestar y mejorar el servicio:
+            conectar tus canales de mensajería, gestionar conversaciones con tus
+            clientes y generar reportes para tu negocio. No vendemos tu
+            información a terceros.
+          </p>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">
+            4. Almacenamiento y seguridad
+          </h2>
+          <p>
+            Aplicamos medidas técnicas y organizativas razonables para proteger
+            tu información y la conservamos solo durante el tiempo necesario para
+            prestar el servicio o cumplir obligaciones legales.
+          </p>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">5. Tus derechos</h2>
+          <p>
+            Puedes solicitar el acceso, la corrección o la eliminación de tus
+            datos, así como revocar las integraciones conectadas en cualquier
+            momento desde tu cuenta o escribiéndonos.
+          </p>
+        </section>
+
+        <section class="mb-6">
+          <h2 class="text-h6 font-weight-bold mb-2">6. Contacto</h2>
+          <p>
+            Si tienes preguntas sobre esta política, escríbenos a
+            <a href="mailto:contacto@todofull.club">contacto@todofull.club</a>.
+          </p>
+        </section>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: "PrivacyPolicy",
+};
+</script>


### PR DESCRIPTION
## Qué
La raíz `/` de todofull.club dejaba de redirigir a `/login` y ahora renderiza un **landing público provisional** (`Landing.vue`): marca Todofull, propuesta de valor (español neutro Latam, sin voseo), CTA a `/login` y link a la Política de privacidad. Se agrega `/privacy-policy` (`PrivacyPolicy.vue`) para que el link resuelva — **Meta App Review verifica que la URL cargue**.

`/login` y el guard `requiresAuth` del resto quedan intactos.

## Notas
- Contacto placeholder `contacto@todofull.club` en la política — confirmar que el buzón exista antes del review.
- `src/views/LandingPage.vue` legacy queda huérfano (limpieza follow-up, no lo borré por regla surgical).